### PR TITLE
SYSUP-1080 switch package version SO based

### DIFF
--- a/sensu/client_install.sls
+++ b/sensu/client_install.sls
@@ -11,8 +11,11 @@ install_gems_compilling:
 install_sensu_client:
   pkg.installed:
     - name: sensu
+    {% if  grains['os'] == 'CentOS' %}
     - version: 1:0.26.5-2
+    {% elif grains['os'] == 'Debian' %}
+    - version: 0.26.5-2
+    {% endif %}
     - hold: True
     - require:
       - pkgrepo: sensu
-


### PR DESCRIPTION
SYSUP-1080 enabling logic to install Sensu 0.26.5-2 only in Debian OS.